### PR TITLE
Port improvements / changes from 3.0 to 11.x

### DIFF
--- a/config/totem.php
+++ b/config/totem.php
@@ -227,4 +227,7 @@ return [
         'command_filter' => [],
         'whitelist' => true,
     ],
+    'cache' => [
+        'enabled' => env('TOTEM_CACHE_ENABLED', true),
+    ]
 ];

--- a/config/totem.php
+++ b/config/totem.php
@@ -229,5 +229,8 @@ return [
     ],
     'cache' => [
         'enabled' => env('TOTEM_CACHE_ENABLED', true),
-    ]
+    ],
+    'overlapping' => [
+        'mutex_expiry' => env('TOTEM_OVERLAPPING_MUTEX_EXPIRY', 1440), // in minutes
+    ],
 ];

--- a/config/totem.php
+++ b/config/totem.php
@@ -233,4 +233,8 @@ return [
     'overlapping' => [
         'mutex_expiry' => env('TOTEM_OVERLAPPING_MUTEX_EXPIRY', 1440), // in minutes
     ],
+    'pagination' => [
+        'tasks_per_page' => env('TOTEM_TASKS_PER_PAGE', 20),
+        'results_per_page' => env('TOTEM_RESULTS_PER_PAGE', 10),
+    ],
 ];

--- a/config/totem.php
+++ b/config/totem.php
@@ -237,4 +237,8 @@ return [
         'tasks_per_page' => env('TOTEM_TASKS_PER_PAGE', 20),
         'results_per_page' => env('TOTEM_RESULTS_PER_PAGE', 10),
     ],
+    'broadcasting' => [
+        'enabled' => env('TOTEM_BROADCASTING_ENABLED', true),
+        'channel' => env('TOTEM_BROADCASTING_CHANNEL', 'task.events'),
+    ],
 ];

--- a/resources/views/tasks/form.blade.php
+++ b/resources/views/tasks/form.blade.php
@@ -239,10 +239,10 @@
                 <input class="uk-input" type="number" name="auto_cleanup_num" id="auto_cleanup_num" value="{{ old('auto_cleanup_num', $task->auto_cleanup_num) ?? 0 }}" />
                 <br>
                 <label>
-                    <input type="radio" name="auto_cleanup_type" value="days" {{old('auto_cleanup_type', $task->auto_cleanup_type) !== 'results' ? '' : 'checked'}}> Days
+                    <input type="radio" name="auto_cleanup_type" value="days" {{old('auto_cleanup_type', $task->auto_cleanup_type) !== 'results' ? 'checked' : ''}}> Days
                 </label><br>
                 <label>
-                    <input type="radio" name="auto_cleanup_type" value="results" {{old('auto_cleanup_type', $task->auto_cleanup_type) === 'results' ? '' : 'checked'}}> Results
+                    <input type="radio" name="auto_cleanup_type" value="results" {{old('auto_cleanup_type', $task->auto_cleanup_type) === 'results' ? 'checked' : ''}}> Results
                 </label>
             </label>
         </div>

--- a/resources/views/tasks/view.blade.php
+++ b/resources/views/tasks/view.blade.php
@@ -106,7 +106,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                @forelse($results = $task->results()->orderByDesc('created_at')->paginate(10) as $result)
+                @forelse($results = $task->results()->orderByDesc('created_at')->paginate(config('totem.pagination.results_per_page')) as $result)
                     <tr>
                         <td>{{$result->ran_at->toDateTimeString()}}</td>
                         <td>{{ number_format($result->duration / 1000 , 2)}} seconds</td>

--- a/src/Console/Commands/ListSchedule.php
+++ b/src/Console/Commands/ListSchedule.php
@@ -58,9 +58,9 @@ class ListSchedule extends Command
                     'timezone'      => $event->timezone ?: config('app.timezone'),
                     'overlaps'      => $event->withoutOverlapping ? 'No' : 'Yes',
                     'maintenance'   => $event->evenInMaintenanceMode ? 'Yes' : 'No',
-                    'one_server'   => $event->onOneServer ? 'Yes' : 'No',
+                    'one_server'    => $event->onOneServer ? 'Yes' : 'No',
                 ];
-            });
+            })->sortBy(['description']);
 
             $this->table(
                 ['Description', 'Command', 'Schedule', 'Upcoming', 'Timezone', 'Overlaps?', 'In Maintenance?', 'One Server?'],

--- a/src/Events/BroadcastingEvent.php
+++ b/src/Events/BroadcastingEvent.php
@@ -33,6 +33,16 @@ class BroadcastingEvent extends TaskEvent implements ShouldBroadcast
      */
     public function broadcastOn()
     {
-        return new PrivateChannel('task.events');
+        return new PrivateChannel(config('totem.broadcasting.channel'));
+    }
+
+    /**
+     * Toggles event broadcasting on/off based on config value.
+     *
+     * @return bool
+     */
+    public function broadcastWhen()
+    {
+        return config('totem.broadcasting.enabled');
     }
 }

--- a/src/Http/Controllers/TasksController.php
+++ b/src/Http/Controllers/TasksController.php
@@ -42,7 +42,7 @@ class TasksController extends Controller
                 ->when(request('q'), function ($query) {
                     $query->where('description', 'LIKE', '%'.request('q').'%');
                 })
-                ->paginate(20),
+                ->paginate(config('totem.pagination.tasks_per_page')),
         ]);
     }
 

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -45,7 +45,7 @@ class ConsoleServiceProvider extends ServiceProvider
                 })
                 ->sendOutputTo(storage_path($task->getMutexName()));
             if ($task->dont_overlap) {
-                $event->withoutOverlapping();
+                $event->withoutOverlapping(config('totem.overlapping.mutex_expiry'));
             }
             if ($task->run_in_maintenance) {
                 $event->evenInMaintenanceMode();

--- a/src/Providers/TotemRouteServiceProvider.php
+++ b/src/Providers/TotemRouteServiceProvider.php
@@ -27,9 +27,13 @@ class TotemRouteServiceProvider extends RouteServiceProvider
         parent::boot();
 
         Route::bind('task', function ($value) {
-            return cache()->rememberForever('totem.task.'.$value, function () use ($value) {
+            if (config('totem.cache.enabled')) {
+                return cache()->rememberForever('totem.task.'.$value, function () use ($value) {
+                    return Task::find($value) ?? abort(404);
+                });
+            } else {
                 return Task::find($value) ?? abort(404);
-            });
+            }
         });
     }
 

--- a/src/Providers/TotemServiceProvider.php
+++ b/src/Providers/TotemServiceProvider.php
@@ -53,7 +53,9 @@ class TotemServiceProvider extends ServiceProvider
         $this->app->bindIf('totem.tasks', EloquentTaskRepository::class, true);
         $this->app->alias('totem.tasks', TaskInterface::class);
         $this->app->register(TotemRouteServiceProvider::class);
-        $this->app->register(TotemEventServiceProvider::class);
+        if (config('totem.cache.enabled')) {
+            $this->app->register(TotemEventServiceProvider::class);
+        }
         $this->app->register(TotemFormServiceProvider::class);
 
         $this->mergeConfigFrom(

--- a/src/Repositories/EloquentTaskRepository.php
+++ b/src/Repositories/EloquentTaskRepository.php
@@ -40,9 +40,13 @@ class EloquentTaskRepository implements TaskInterface
             return $id;
         }
 
-        return Cache::rememberForever('totem.task.'.$id, function () use ($id) {
+        if (config('totem.cache.enabled')) {
+            return Cache::rememberForever('totem.task.'.$id, function () use ($id) {
+                return Task::find($id);
+            });
+        } else {
             return Task::find($id);
-        });
+        }
     }
 
     /**
@@ -52,9 +56,13 @@ class EloquentTaskRepository implements TaskInterface
      */
     public function findAll()
     {
-        return Cache::rememberForever('totem.tasks.all', function () {
+        if (config('totem.cache.enabled')) {
+            return Cache::rememberForever('totem.tasks.all', function () {
+                return Task::all();
+            });
+        } else {
             return Task::all();
-        });
+        }
     }
 
     /**
@@ -64,11 +72,17 @@ class EloquentTaskRepository implements TaskInterface
      */
     public function findAllActive()
     {
-        return Cache::rememberForever('totem.tasks.active', function () {
+        if (config('totem.cache.enabled')) {
+            return Cache::rememberForever('totem.tasks.active', function () {
+                return $this->findAll()->filter(function ($task) {
+                    return $task->is_active;
+                });
+            });
+        } else {
             return $this->findAll()->filter(function ($task) {
                 return $task->is_active;
             });
-        });
+        }
     }
 
     /**

--- a/src/Task.php
+++ b/src/Task.php
@@ -179,7 +179,7 @@ class Task extends TotemModel
                     ->delete();
             } else {
                 self::results()
-                    ->where('ran_at', '<', Carbon::now()->subDays($this->auto_cleanup_num - 1))
+                    ->where('ran_at', '<', Carbon::now()->subDays($this->auto_cleanup_num))
                     ->delete();
             }
         }

--- a/src/Traits/HasFrequencies.php
+++ b/src/Traits/HasFrequencies.php
@@ -122,7 +122,7 @@ trait HasFrequencies
      */
     public function getMutexName()
     {
-        return 'logs'.DIRECTORY_SEPARATOR.'schedule-'.sha1($this->expression.$this->command);
+        return 'logs'.DIRECTORY_SEPARATOR.'schedule-'.sha1($this->expression.$this->command.$this->parameters);
     }
 
     /**


### PR DESCRIPTION
- Improvement: Config options for broadcasting [merge not needed, was already implemented in origin by 11.x]
- Improvement: Config options for pagination
- Fix: Task results auto cleanup correct number of days
- Improvement: Config option for mutex expiry overlapping check
- Breaking change: different params for same command generates different log file name; in short, tasks uniqueness is now dependent on command name + command params + scheduling time [merge not needed; was already implemented in origin by 11.x, then log files were removed completely]
- Improvement: config option to disable caching (useful when updating task directly from DB / via migrations)
- Improvement: schedule:list command - sort by task description
- Fix: "Auto Cleanup Type" was inverted in task edit form